### PR TITLE
MailHog を導入する

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -10,6 +10,8 @@ services:
       MYSQL_HOST: db
       MYSQL_USER: root
       MYSQL_PASSWORD: password
+      SMTP_HOST: mailhog
+      SMTP_PORT: 1025
     volumes:
       - type: bind
         source: ./webapp
@@ -17,6 +19,7 @@ services:
     depends_on:
       - db
       - redis
+      - mailhog
     tty: true
 
   db:
@@ -39,3 +42,12 @@ services:
       - '6379:6379'
     volumes:
       - ./data/redis:/data
+
+  mailhog:
+    image: mailhog/mailhog:latest
+    restart: always
+    ports:
+      - '1025:1025'  # SMTP server
+      - '8025:8025'  # Web UI
+    environment:
+      MH_STORAGE: memory

--- a/webapp/config/environments/development.rb
+++ b/webapp/config/environments/development.rb
@@ -42,7 +42,7 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.perform_caching = false
 
@@ -50,9 +50,10 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-    address: 'localhost',
-    port: 1025,
-    domain: 'localhost'
+    address: ENV.fetch('SMTP_HOST', 'localhost'),
+    port: ENV.fetch('SMTP_PORT', 1025).to_i,
+    domain: 'localhost',
+    enable_starttls_auto: false
   }
 
   # Print deprecation notices to the Rails logger.


### PR DESCRIPTION
## Issue 番号
- fixes #7 

## PR 概要
- MailHog を導入し、ローカル環境でのメールテストを行えるようにする。

## PR 詳細
### やったこと
- compose.yml に mailhog を追加
- development.rb に設定を追加
- ユーザ作成時のメール送信を確認する

### やらなかったこと
- stg, prod 環境のメール設定
  - 別途 AWS SES か SendGrid などでやるかも

## 補足事項
- N/A
