### PR TITLE
Sidekiq の導入

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -43,6 +43,26 @@ services:
     volumes:
       - ./data/redis:/data
 
+  worker:
+    restart: always
+    build: .
+    command: bundle exec sidekiq
+    environment:
+      MYSQL_HOST: db
+      MYSQL_USER: root
+      MYSQL_PASSWORD: password
+      SMTP_HOST: mailhog
+      SMTP_PORT: 1025
+    volumes:
+      - type: bind
+        source: ./webapp
+        target: /webapp
+    depends_on:
+      - db
+      - redis
+      - mailhog
+    tty: true
+
   mailhog:
     image: mailhog/mailhog:latest
     restart: always

--- a/webapp/Gemfile
+++ b/webapp/Gemfile
@@ -31,6 +31,9 @@ gem 'jbuilder'
 # Use Redis adapter to run Action Cable in production
 gem 'redis', '>= 4.0.1'
 
+# Background job processing with Sidekiq
+gem 'sidekiq'
+
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"
 

--- a/webapp/Gemfile.lock
+++ b/webapp/Gemfile.lock
@@ -311,6 +311,12 @@ GEM
       websocket (~> 1.0)
     shoulda-matchers (6.5.0)
       activesupport (>= 5.2.0)
+    sidekiq (8.0.7)
+      connection_pool (>= 2.5.0)
+      json (>= 2.9.0)
+      logger (>= 1.6.2)
+      rack (>= 3.1.0)
+      redis-client (>= 0.23.2)
     sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
       logger
@@ -380,6 +386,7 @@ DEPENDENCIES
   rubocop-rspec
   selenium-webdriver
   shoulda-matchers
+  sidekiq
   sprockets-rails
   stimulus-rails
   turbo-rails

--- a/webapp/config/application.rb
+++ b/webapp/config/application.rb
@@ -24,7 +24,7 @@ module Webapp
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
 
-    # Configure Active Job to use default adapter (async for development)
-    # config.active_job.queue_adapter = :redis
+    # Configure Active Job to use Sidekiq adapter
+    config.active_job.queue_adapter = :sidekiq
   end
 end

--- a/webapp/config/initializers/sidekiq.rb
+++ b/webapp/config/initializers/sidekiq.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sidekiq.configure_server do |config|
+  config.redis = { url: 'redis://redis:6379/0' }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: 'redis://redis:6379/0' }
+end

--- a/webapp/config/initializers/sidekiq.rb
+++ b/webapp/config/initializers/sidekiq.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 Sidekiq.configure_server do |config|
-  config.redis = { url: 'redis://redis:6379/0' }
+  config.redis = { url: ENV.fetch('REDIS_URL', 'redis://redis:6379/0') }
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = { url: 'redis://redis:6379/0' }
+  config.redis = { url: ENV.fetch('REDIS_URL', 'redis://redis:6379/0') }
 end

--- a/webapp/config/routes.rb
+++ b/webapp/config/routes.rb
@@ -1,8 +1,13 @@
 # frozen_string_literal: true
 
+require 'sidekiq/web'
+
 Rails.application.routes.draw do
   devise_for :users
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
+
+  # Sidekiq Web interface
+  mount Sidekiq::Web => '/sidekiq'
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.

--- a/webapp/config/routes.rb
+++ b/webapp/config/routes.rb
@@ -7,6 +7,8 @@ Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Sidekiq Web interface
+  # TODO: sidekiq を見られる範囲を限定する。
+  #       e.g. admins をつくって authenticate する？
   mount Sidekiq::Web => '/sidekiq'
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
## Issue 番号
- fixes #11 

## PR 概要
- Sidekiq の導入を行い、ジョブキューによる非同期処理ができるようにする。

## PR 詳細
### やったこと
- Sidekiq gem の追加
- worker container の作成
- Sidekiq の初期設定
  - Redis との接続
  - routes に sidekiq を追加し、ダッシュボードを確認する
- 一時的な job の作成→ジョブキューに送られるまで確認
  - ActionMailer との連携も OK。

### やらなかったこと
- 作成した job の push
  - 余計なものを増やさないため。

## 補足事項
- N/A
