### PR TITLE
Tailwind CSS の導入

### DIFF
--- a/webapp/.gitignore
+++ b/webapp/.gitignore
@@ -67,3 +67,6 @@ yarn-debug.log*
 /storage/*
 !/storage/.keep
 /public/uploads
+
+/app/assets/builds/*
+!/app/assets/builds/.keep

--- a/webapp/Gemfile
+++ b/webapp/Gemfile
@@ -25,6 +25,9 @@ gem 'turbo-rails'
 # Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
 gem 'stimulus-rails'
 
+# Tailwind CSS for styling [https://github.com/rails/tailwindcss-rails]
+gem 'tailwindcss-rails'
+
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem 'jbuilder'
 

--- a/webapp/Gemfile.lock
+++ b/webapp/Gemfile.lock
@@ -328,6 +328,16 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.7)
+    tailwindcss-rails (4.3.0)
+      railties (>= 7.0.0)
+      tailwindcss-ruby (~> 4.0)
+    tailwindcss-ruby (4.1.12)
+    tailwindcss-ruby (4.1.12-aarch64-linux-gnu)
+    tailwindcss-ruby (4.1.12-aarch64-linux-musl)
+    tailwindcss-ruby (4.1.12-arm64-darwin)
+    tailwindcss-ruby (4.1.12-x86_64-darwin)
+    tailwindcss-ruby (4.1.12-x86_64-linux-gnu)
+    tailwindcss-ruby (4.1.12-x86_64-linux-musl)
     thor (1.4.0)
     timeout (0.4.3)
     turbo-rails (2.0.16)
@@ -389,6 +399,7 @@ DEPENDENCIES
   sidekiq
   sprockets-rails
   stimulus-rails
+  tailwindcss-rails
   turbo-rails
   tzinfo-data
   web-console

--- a/webapp/Procfile.dev
+++ b/webapp/Procfile.dev
@@ -1,0 +1,2 @@
+web: bin/rails server
+css: bin/rails tailwindcss:watch

--- a/webapp/app/assets/config/manifest.js
+++ b/webapp/app/assets/config/manifest.js
@@ -2,3 +2,4 @@
 //= link_directory ../stylesheets .css
 //= link_tree ../../javascript .js
 //= link_tree ../../../vendor/javascript .js
+//= link_tree ../builds

--- a/webapp/app/assets/tailwind/application.css
+++ b/webapp/app/assets/tailwind/application.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/webapp/app/controllers/application_controller.rb
+++ b/webapp/app/controllers/application_controller.rb
@@ -5,10 +5,20 @@ class ApplicationController < ActionController::Base
 
   before_action :configure_permitted_parameters, if: :devise_controller?
 
+  layout :layout_by_resource
+
   private
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
     devise_parameter_sanitizer.permit(:account_update, keys: [:name])
+  end
+
+  def layout_by_resource
+    if devise_controller?
+      'devise'
+    else
+      'application'
+    end
   end
 end

--- a/webapp/app/controllers/home_controller.rb
+++ b/webapp/app/controllers/home_controller.rb
@@ -1,0 +1,4 @@
+class HomeController < ApplicationController
+  def index
+  end
+end

--- a/webapp/app/helpers/home_helper.rb
+++ b/webapp/app/helpers/home_helper.rb
@@ -1,0 +1,2 @@
+module HomeHelper
+end

--- a/webapp/app/views/devise/passwords/new.html.erb
+++ b/webapp/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,31 @@
-<h2>Forgot your password?</h2>
+<div class="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+  <div class="max-w-md w-full space-y-8">
+    <div>
+      <h2 class="mt-6 text-center text-3xl font-extrabold text-gray-900">
+        パスワードをお忘れですか？
+      </h2>
+      <p class="mt-2 text-center text-sm text-gray-600">
+        登録されたメールアドレスにパスワードリセットの手順をお送りします
+      </p>
+    </div>
+    <div class="bg-white shadow-md rounded-lg px-8 pt-6 pb-8 mb-4">
+      <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }, local: true, class: "space-y-6") do |f| %>
+        <%= render "devise/shared/error_messages", resource: resource %>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+        <div>
+          <%= f.label :email, "メールアドレス", class: "block text-sm font-medium text-gray-700" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email",
+                           class: "mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
+        </div>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+        <div>
+          <%= f.submit "パスワードリセット手順を送信", class: "group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition duration-150 ease-in-out cursor-pointer" %>
+        </div>
+      <% end %>
+
+      <div class="mt-6">
+        <%= render "devise/shared/links" %>
+      </div>
+    </div>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/webapp/app/views/devise/registrations/new.html.erb
+++ b/webapp/app/views/devise/registrations/new.html.erb
@@ -1,34 +1,49 @@
-<h2>Sign up</h2>
+<div class="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+  <div class="max-w-md w-full space-y-8">
+    <div>
+      <h2 class="mt-6 text-center text-3xl font-extrabold text-gray-900">
+        新規登録
+      </h2>
+    </div>
+    <div class="bg-white shadow-md rounded-lg px-8 pt-6 pb-8 mb-4">
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), local: true, class: "space-y-6") do |f| %>
+        <%= render "devise/shared/error_messages", resource: resource %>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+        <div>
+          <%= f.label :name, "名前", class: "block text-sm font-medium text-gray-700" %>
+          <%= f.text_field :name, autofocus: true, autocomplete: "name",
+                           class: "mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
+        </div>
 
-  <div class="field">
-    <%= f.label :name %><br />
-    <%= f.text_field :name, autofocus: true, autocomplete: "name" %>
+        <div>
+          <%= f.label :email, "メールアドレス", class: "block text-sm font-medium text-gray-700" %>
+          <%= f.email_field :email, autocomplete: "email",
+                           class: "mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
+        </div>
+
+        <div>
+          <%= f.label :password, "パスワード", class: "block text-sm font-medium text-gray-700" %>
+          <% if @minimum_password_length %>
+            <p class="text-xs text-gray-500 mt-1">(<%= @minimum_password_length %>文字以上)</p>
+          <% end %>
+          <%= f.password_field :password, autocomplete: "new-password",
+                              class: "mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
+        </div>
+
+        <div>
+          <%= f.label :password_confirmation, "パスワード確認", class: "block text-sm font-medium text-gray-700" %>
+          <%= f.password_field :password_confirmation, autocomplete: "new-password",
+                              class: "mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
+        </div>
+
+        <div>
+          <%= f.submit "登録", class: "group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition duration-150 ease-in-out cursor-pointer" %>
+        </div>
+      <% end %>
+
+      <div class="mt-6">
+        <%= render "devise/shared/links" %>
+      </div>
+    </div>
   </div>
-
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autocomplete: "email" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password %>
-    <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
-    <% end %><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Sign up" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/webapp/app/views/devise/sessions/new.html.erb
+++ b/webapp/app/views/devise/sessions/new.html.erb
@@ -1,26 +1,39 @@
-<h2>Log in</h2>
-
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
-  </div>
-
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
+<div class="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+  <div class="max-w-md w-full space-y-8">
+    <div>
+      <h2 class="mt-6 text-center text-3xl font-extrabold text-gray-900">
+        ログイン
+      </h2>
     </div>
-  <% end %>
+    <div class="bg-white shadow-md rounded-lg px-8 pt-6 pb-8 mb-4">
+      <%= form_for(resource, as: resource_name, url: session_path(resource_name), local: true, class: "space-y-6") do |f| %>
+        <div>
+          <%= f.label :email, class: "block text-sm font-medium text-gray-700" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email",
+                           class: "mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
+        </div>
 
-  <div class="actions">
-    <%= f.submit "Log in" %>
+        <div>
+          <%= f.label :password, "パスワード", class: "block text-sm font-medium text-gray-700" %>
+          <%= f.password_field :password, autocomplete: "current-password",
+                              class: "mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
+        </div>
+
+        <% if devise_mapping.rememberable? %>
+          <div class="flex items-center">
+            <%= f.check_box :remember_me, class: "h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded" %>
+            <%= f.label :remember_me, "ログイン状態を保持する", class: "ml-2 block text-sm text-gray-900" %>
+          </div>
+        <% end %>
+
+        <div>
+          <%= f.submit "ログイン", class: "group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition duration-150 ease-in-out cursor-pointer" %>
+        </div>
+      <% end %>
+
+      <div class="mt-6">
+        <%= render "devise/shared/links" %>
+      </div>
+    </div>
   </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/webapp/app/views/devise/shared/_error_messages.html.erb
+++ b/webapp/app/views/devise/shared/_error_messages.html.erb
@@ -1,15 +1,26 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation" data-turbo-cache="false">
-    <h2>
-      <%= I18n.t("errors.messages.not_saved",
-                 count: resource.errors.count,
-                 resource: resource.class.model_name.human.downcase)
-       %>
-    </h2>
-    <ul>
-      <% resource.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-    </ul>
+  <div id="error_explanation" data-turbo-cache="false" class="bg-red-50 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
+    <div class="flex">
+      <div class="flex-shrink-0">
+        <svg class="h-5 w-5 text-red-400" viewBox="0 0 20 20" fill="currentColor">
+          <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
+        </svg>
+      </div>
+      <div class="ml-3">
+        <h3 class="text-sm font-medium text-red-800">
+          <%= I18n.t("errors.messages.not_saved",
+                     count: resource.errors.count,
+                     resource: resource.class.model_name.human.downcase)
+           %>
+        </h3>
+        <div class="mt-2 text-sm text-red-700">
+          <ul class="list-disc list-inside space-y-1">
+            <% resource.errors.full_messages.each do |message| %>
+              <li><%= message %></li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+    </div>
   </div>
 <% end %>

--- a/webapp/app/views/devise/shared/_links.html.erb
+++ b/webapp/app/views/devise/shared/_links.html.erb
@@ -1,25 +1,27 @@
-<%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
-<% end %>
-
-<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
-<% end %>
-
-<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
-<% end %>
-
-<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
-<% end %>
-
-<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
-<% end %>
-
-<%- if devise_mapping.omniauthable? %>
-  <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false } %><br />
+<div class="text-center space-y-2">
+  <%- if controller_name != 'sessions' %>
+    <%= link_to "ログイン", new_session_path(resource_name), class: "text-indigo-600 hover:text-indigo-500 font-medium transition duration-150 ease-in-out" %>
   <% end %>
-<% end %>
+
+  <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+    <%= link_to "新規登録", new_registration_path(resource_name), class: "text-indigo-600 hover:text-indigo-500 font-medium transition duration-150 ease-in-out" %>
+  <% end %>
+
+  <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+    <%= link_to "パスワードを忘れましたか？", new_password_path(resource_name), class: "text-indigo-600 hover:text-indigo-500 font-medium transition duration-150 ease-in-out" %>
+  <% end %>
+
+  <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+    <%= link_to "確認メールが届きませんか？", new_confirmation_path(resource_name), class: "text-indigo-600 hover:text-indigo-500 font-medium transition duration-150 ease-in-out" %>
+  <% end %>
+
+  <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+    <%= link_to "ロック解除メールが届きませんか？", new_unlock_path(resource_name), class: "text-indigo-600 hover:text-indigo-500 font-medium transition duration-150 ease-in-out" %>
+  <% end %>
+
+  <%- if devise_mapping.omniauthable? %>
+    <%- resource_class.omniauth_providers.each do |provider| %>
+      <%= button_to "#{OmniAuth::Utils.camelize(provider)}でサインイン", omniauth_authorize_path(resource_name, provider), data: { turbo: false }, class: "w-full bg-gray-800 text-white py-2 px-4 rounded-md hover:bg-gray-700 transition duration-150 ease-in-out" %>
+    <% end %>
+  <% end %>
+</div>

--- a/webapp/app/views/home/index.html.erb
+++ b/webapp/app/views/home/index.html.erb
@@ -9,7 +9,7 @@
         <div class="flex space-x-4">
           <% if user_signed_in? %>
             <span class="text-gray-700">こんにちは、<%= current_user.name %>さん</span>
-            <%= link_to "ログアウト", destroy_user_session_path, method: :delete,
+            <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete },
                        class: "bg-indigo-600 text-white px-4 py-2 rounded-md hover:bg-indigo-700 transition duration-150 ease-in-out" %>
           <% else %>
             <%= link_to "ログイン", new_user_session_path,

--- a/webapp/app/views/home/index.html.erb
+++ b/webapp/app/views/home/index.html.erb
@@ -1,0 +1,102 @@
+<div class="min-h-screen bg-gradient-to-br from-indigo-600 via-purple-600 to-pink-500">
+  <!-- Navigation -->
+  <nav class="bg-white shadow-lg">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="flex justify-between items-center h-16">
+        <div class="flex items-center">
+          <h1 class="text-xl font-bold text-gray-800">WebApp</h1>
+        </div>
+        <div class="flex space-x-4">
+          <% if user_signed_in? %>
+            <span class="text-gray-700">こんにちは、<%= current_user.name %>さん</span>
+            <%= link_to "ログアウト", destroy_user_session_path, method: :delete,
+                       class: "bg-indigo-600 text-white px-4 py-2 rounded-md hover:bg-indigo-700 transition duration-150 ease-in-out" %>
+          <% else %>
+            <%= link_to "ログイン", new_user_session_path,
+                       class: "text-indigo-600 hover:text-indigo-500 font-medium transition duration-150 ease-in-out" %>
+            <%= link_to "新規登録", new_user_registration_path,
+                       class: "bg-indigo-600 text-white px-4 py-2 rounded-md hover:bg-indigo-700 transition duration-150 ease-in-out" %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <!-- Hero Section -->
+  <div class="relative py-24">
+    <div class="max-w-7xl mx-auto text-center px-4 sm:px-6 lg:px-8">
+      <h1 class="text-5xl md:text-6xl font-extrabold text-white mb-6">
+        Welcome to
+        <span class="text-transparent bg-clip-text bg-gradient-to-r from-yellow-400 to-orange-500">
+          WebApp
+        </span>
+      </h1>
+      <p class="text-xl md:text-2xl text-indigo-100 mb-8 max-w-3xl mx-auto">
+        モダンなWebアプリケーションで、新しい体験を始めましょう。
+        Tailwind CSSでスタイリングされた美しいインターフェースをお楽しみください。
+      </p>
+      <div class="flex flex-col sm:flex-row gap-4 justify-center">
+        <% unless user_signed_in? %>
+          <%= link_to new_user_registration_path,
+                     class: "bg-white text-indigo-600 px-8 py-3 rounded-lg font-semibold text-lg hover:bg-gray-100 transition duration-150 ease-in-out shadow-lg" do %>
+            今すぐ始める
+          <% end %>
+          <%= link_to new_user_session_path,
+                     class: "border-2 border-white text-white px-8 py-3 rounded-lg font-semibold text-lg hover:bg-white hover:text-indigo-600 transition duration-150 ease-in-out" do %>
+            ログイン
+          <% end %>
+        <% else %>
+          <div class="bg-white text-indigo-600 px-8 py-3 rounded-lg font-semibold text-lg shadow-lg">
+            ログイン中です！
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+
+  <!-- Features Section -->
+  <div class="bg-white py-24">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="text-center mb-16">
+        <h2 class="text-3xl md:text-4xl font-extrabold text-gray-900 mb-4">
+          主な機能
+        </h2>
+        <p class="text-xl text-gray-600 max-w-2xl mx-auto">
+          最新技術を使用した高性能なWebアプリケーション
+        </p>
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+        <div class="text-center p-6">
+          <div class="bg-indigo-100 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
+            <svg class="w-8 h-8 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path>
+            </svg>
+          </div>
+          <h3 class="text-xl font-semibold text-gray-900 mb-2">高速パフォーマンス</h3>
+          <p class="text-gray-600">Redis、Sidekiqを使用したバックグラウンド処理で高速なレスポンスを実現</p>
+        </div>
+
+        <div class="text-center p-6">
+          <div class="bg-purple-100 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
+            <svg class="w-8 h-8 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"></path>
+            </svg>
+          </div>
+          <h3 class="text-xl font-semibold text-gray-900 mb-2">セキュア認証</h3>
+          <p class="text-gray-600">Deviseを使用した堅牢なユーザー認証システム</p>
+        </div>
+
+        <div class="text-center p-6">
+          <div class="bg-pink-100 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
+            <svg class="w-8 h-8 text-pink-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17v4a2 2 0 002 2h4M13 13h4a2 2 0 012 2v4a2 2 0 01-2 2H9a2 2 0 01-2-2v-4a2 2 0 012-2h4z"></path>
+            </svg>
+          </div>
+          <h3 class="text-xl font-semibold text-gray-900 mb-2">モダンUI</h3>
+          <p class="text-gray-600">Tailwind CSSによる美しく、レスポンシブなユーザーインターフェース</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/webapp/app/views/layouts/devise.html.erb
+++ b/webapp/app/views/layouts/devise.html.erb
@@ -6,12 +6,11 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
-
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
 
-  <body>
+  <body class="bg-gray-50">
     <%= yield %>
   </body>
 </html>

--- a/webapp/bin/dev
+++ b/webapp/bin/dev
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+if ! gem list foreman -i --silent; then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+# Default to port 3000 if not specified
+export PORT="${PORT:-3000}"
+
+# Let the debug gem allow remote connections,
+# but avoid loading until `debugger` is called
+export RUBY_DEBUG_OPEN="true"
+export RUBY_DEBUG_LAZY="true"
+
+exec foreman start -f Procfile.dev "$@"

--- a/webapp/config/routes.rb
+++ b/webapp/config/routes.rb
@@ -3,6 +3,7 @@
 require 'sidekiq/web'
 
 Rails.application.routes.draw do
+  get 'home/index'
   devise_for :users
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
@@ -16,5 +17,5 @@ Rails.application.routes.draw do
   get 'up' => 'rails/health#show', as: :rails_health_check
 
   # Defines the root path route ("/")
-  # root "posts#index"
+  root 'home#index'
 end

--- a/webapp/spec/helpers/home_helper_spec.rb
+++ b/webapp/spec/helpers/home_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the HomeHelper. For example:
+#
+# describe HomeHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe HomeHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/webapp/spec/requests/home_spec.rb
+++ b/webapp/spec/requests/home_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe "Homes", type: :request do
+  describe "GET /index" do
+    it "returns http success" do
+      get "/home/index"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/webapp/spec/views/home/index.html.tailwindcss_spec.rb
+++ b/webapp/spec/views/home/index.html.tailwindcss_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "home/index.html.tailwindcss", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## Issue 番号
- fixes #12 

## PR 概要
- Tailwind CSS を導入し、見た目をよくする。

## PR 詳細
### やったこと
- Tailwind CSS を入れ、初期設定を行う
- devise 周りのページのスタイリング
- root ページの更新
  - とりあえず仮でつくらせてみた。ログイン周りは成功していそう。

<img width="1784" height="930" alt="image" src="https://github.com/user-attachments/assets/2cf8b174-52f7-4ba0-8fcc-a607398198f9" />

### やらなかったこと
- ページデザインの精査
  - とりあえず動くものができればいいので、デザインの精査はしない方向で…
- ログイン後の redirect 先の設定
  - user 周りのページをつくる際に考える。

## 補足事項
- N/A
