### PR TITLE
簡単なユーザマイページの作成

### DIFF
--- a/webapp/.rubocop.yml
+++ b/webapp/.rubocop.yml
@@ -51,6 +51,9 @@ Style/TrailingCommaInHashLiteral:
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: no_comma
 
+Style/EmptyMethod:
+  Enabled: false
+
 # Metrics
 Metrics/BlockLength:
   Exclude:
@@ -107,4 +110,7 @@ RSpec/SortMetadata:
   Enabled: false
 
 RSpec/MetadataStyle:
+  Enabled: false
+
+RSpec/ContextWording:
   Enabled: false

--- a/webapp/app/controllers/application_controller.rb
+++ b/webapp/app/controllers/application_controller.rb
@@ -9,7 +9,7 @@ class ApplicationController < ActionController::Base
 
   private
 
-  def after_sign_in_path_for(resource)
+  def after_sign_in_path_for(_resource)
     users_mypage_path
   end
 

--- a/webapp/app/controllers/application_controller.rb
+++ b/webapp/app/controllers/application_controller.rb
@@ -9,6 +9,10 @@ class ApplicationController < ActionController::Base
 
   private
 
+  def after_sign_in_path_for(resource)
+    users_mypage_path
+  end
+
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
     devise_parameter_sanitizer.permit(:account_update, keys: [:name])

--- a/webapp/app/controllers/home_controller.rb
+++ b/webapp/app/controllers/home_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class HomeController < ApplicationController
   def index
   end

--- a/webapp/app/controllers/users_controller.rb
+++ b/webapp/app/controllers/users_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class UsersController < ApplicationController
+  before_action :authenticate_user!
+
+  def mypage
+    # マイページの表示
+  end
+end

--- a/webapp/app/controllers/users_controller.rb
+++ b/webapp/app/controllers/users_controller.rb
@@ -4,6 +4,5 @@ class UsersController < ApplicationController
   before_action :authenticate_user!
 
   def mypage
-    # マイページの表示
   end
 end

--- a/webapp/app/helpers/home_helper.rb
+++ b/webapp/app/helpers/home_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module HomeHelper
 end

--- a/webapp/app/views/home/index.html.erb
+++ b/webapp/app/views/home/index.html.erb
@@ -9,6 +9,8 @@
         <div class="flex space-x-4">
           <% if user_signed_in? %>
             <span class="text-gray-700">こんにちは、<%= current_user.name %>さん</span>
+            <%= link_to "マイページ", users_mypage_path,
+                       class: "text-indigo-600 hover:text-indigo-500 font-medium transition duration-150 ease-in-out" %>
             <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete },
                        class: "bg-indigo-600 text-white px-4 py-2 rounded-md hover:bg-indigo-700 transition duration-150 ease-in-out" %>
           <% else %>

--- a/webapp/app/views/users/mypage.html.erb
+++ b/webapp/app/views/users/mypage.html.erb
@@ -1,0 +1,96 @@
+<div class="min-h-screen bg-gradient-to-br from-indigo-600 via-purple-600 to-pink-500">
+  <!-- Navigation -->
+  <nav class="bg-white shadow-lg">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="flex justify-between items-center h-16">
+        <div class="flex items-center">
+          <%= link_to root_path, class: "text-xl font-bold text-gray-800 hover:text-indigo-600 transition duration-150 ease-in-out" do %>
+            WebApp
+          <% end %>
+        </div>
+        <div class="flex space-x-4 items-center">
+          <span class="text-gray-700">こんにちは、<%= current_user.name %>さん</span>
+          <%= link_to "マイページ", users_mypage_path,
+                     class: "text-indigo-600 hover:text-indigo-500 font-medium transition duration-150 ease-in-out" %>
+          <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete },
+                     class: "bg-indigo-600 text-white px-4 py-2 rounded-md hover:bg-indigo-700 transition duration-150 ease-in-out" %>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <!-- Main Content -->
+  <div class="relative py-24">
+    <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+      <!-- Welcome Section -->
+      <div class="text-center mb-12">
+        <h1 class="text-4xl md:text-5xl font-extrabold text-white mb-4">
+          マイページ
+        </h1>
+        <p class="text-xl text-indigo-100">
+          こんにちは、<span class="text-yellow-400 font-semibold"><%= current_user.name %></span> さん
+        </p>
+      </div>
+
+      <!-- User Info Card -->
+      <div class="bg-white rounded-2xl shadow-xl p-8 mb-8">
+        <div class="text-center">
+          <div class="bg-indigo-100 w-24 h-24 rounded-full flex items-center justify-center mx-auto mb-6">
+            <svg class="w-12 h-12 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"></path>
+            </svg>
+          </div>
+          <h2 class="text-2xl font-bold text-gray-900 mb-2"><%= current_user.name %></h2>
+          <p class="text-gray-600 mb-6"><%= current_user.email %></p>
+
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm text-gray-600">
+            <div class="bg-gray-50 rounded-lg p-4">
+              <div class="font-medium text-gray-900">登録日</div>
+              <div><%= current_user.created_at.strftime("%Y年%m月%d日") %></div>
+            </div>
+            <div class="bg-gray-50 rounded-lg p-4">
+              <div class="font-medium text-gray-900">最終更新</div>
+              <div><%= current_user.updated_at.strftime("%Y年%m月%d日") %></div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Quick Actions -->
+      <div class="bg-white rounded-2xl shadow-xl p-8">
+        <h3 class="text-xl font-semibold text-gray-900 mb-6 text-center">クイックアクション</h3>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <%= link_to edit_user_registration_path,
+                     class: "bg-indigo-50 hover:bg-indigo-100 border border-indigo-200 rounded-lg p-4 transition duration-150 ease-in-out text-center" do %>
+            <div class="text-indigo-600 mb-2">
+              <svg class="w-8 h-8 mx-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path>
+              </svg>
+            </div>
+            <div class="text-indigo-600 font-medium">プロフィール編集</div>
+          <% end %>
+
+          <%= link_to root_path,
+                     class: "bg-purple-50 hover:bg-purple-100 border border-purple-200 rounded-lg p-4 transition duration-150 ease-in-out text-center" do %>
+            <div class="text-purple-600 mb-2">
+              <svg class="w-8 h-8 mx-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"></path>
+              </svg>
+            </div>
+            <div class="text-purple-600 font-medium">ホームに戻る</div>
+          <% end %>
+
+          <%= link_to destroy_user_session_path, data: { turbo_method: :delete },
+                     class: "bg-pink-50 hover:bg-pink-100 border border-pink-200 rounded-lg p-4 transition duration-150 ease-in-out text-center" do %>
+            <div class="text-pink-600 mb-2">
+              <svg class="w-8 h-8 mx-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"></path>
+              </svg>
+            </div>
+            <div class="text-pink-600 font-medium">ログアウト</div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/webapp/config/environments/test.rb
+++ b/webapp/config/environments/test.rb
@@ -44,6 +44,9 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  # Set default URL options for mailers in test environment
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 

--- a/webapp/config/routes.rb
+++ b/webapp/config/routes.rb
@@ -5,6 +5,10 @@ require 'sidekiq/web'
 Rails.application.routes.draw do
   get 'home/index'
   devise_for :users
+
+  # Users routes
+  get 'users/mypage', to: 'users#mypage', as: 'users_mypage'
+
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Sidekiq Web interface

--- a/webapp/spec/helpers/home_helper_spec.rb
+++ b/webapp/spec/helpers/home_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 # Specs in this file have access to a helper object that includes

--- a/webapp/spec/requests/home_spec.rb
+++ b/webapp/spec/requests/home_spec.rb
@@ -1,11 +1,12 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
-RSpec.describe "Homes", type: :request do
-  describe "GET /index" do
-    it "returns http success" do
-      get "/home/index"
+RSpec.describe 'Homes', type: :request do
+  describe 'GET /index' do
+    it 'returns http success' do
+      get '/home/index'
       expect(response).to have_http_status(:success)
     end
   end
-
 end

--- a/webapp/spec/requests/users_spec.rb
+++ b/webapp/spec/requests/users_spec.rb
@@ -52,8 +52,6 @@ RSpec.describe 'Users', type: :request do
   end
 
   describe 'POST /users/sign_in' do
-    let(:user) { create(:user, name: 'テストユーザー', email: 'test@example.com') }
-
     it 'ログイン後にマイページにリダイレクトされる' do
       # ログインページにアクセス
       get new_user_session_path

--- a/webapp/spec/requests/users_spec.rb
+++ b/webapp/spec/requests/users_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe 'Users', type: :request do
         get users_mypage_path
         expect(response.body).to include(user.name)
         expect(response.body).to include(user.email)
-        expect(response.body).to include(user.created_at.strftime("%Y年%m月%d日"))
-        expect(response.body).to include(user.updated_at.strftime("%Y年%m月%d日"))
+        expect(response.body).to include(user.created_at.strftime('%Y年%m月%d日'))
+        expect(response.body).to include(user.updated_at.strftime('%Y年%m月%d日'))
       end
 
       it 'ナビゲーションにマイページリンクが含まれる' do

--- a/webapp/spec/requests/users_spec.rb
+++ b/webapp/spec/requests/users_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Users', type: :request do
+  let(:user) { create(:user, name: 'テストユーザー', email: 'test@example.com') }
+
+  describe 'GET /users/mypage' do
+    context 'ログインしている場合' do
+      before do
+        sign_in user
+      end
+
+      it 'マイページが正常に表示される' do
+        get users_mypage_path
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'ユーザー名が表示される' do
+        get users_mypage_path
+        expect(response.body).to include("こんにちは、#{user.name}さん") # スペースなし
+        expect(response.body).to include("こんにちは、<span class=\"text-yellow-400 font-semibold\">#{user.name}</span> さん") # メインコンテンツ
+      end
+
+      it 'ユーザーの基本情報が表示される' do
+        get users_mypage_path
+        expect(response.body).to include(user.name)
+        expect(response.body).to include(user.email)
+        expect(response.body).to include(user.created_at.strftime("%Y年%m月%d日"))
+        expect(response.body).to include(user.updated_at.strftime("%Y年%m月%d日"))
+      end
+
+      it 'ナビゲーションにマイページリンクが含まれる' do
+        get users_mypage_path
+        expect(response.body).to include('マイページ')
+      end
+
+      it 'クイックアクションが表示される' do
+        get users_mypage_path
+        expect(response.body).to include('プロフィール編集')
+        expect(response.body).to include('ホームに戻る')
+        expect(response.body).to include('ログアウト')
+      end
+    end
+
+    context 'ログインしていない場合' do
+      it 'ログインページにリダイレクトされる' do
+        get users_mypage_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe 'POST /users/sign_in' do
+    let(:user) { create(:user, name: 'テストユーザー', email: 'test@example.com') }
+
+    it 'ログイン後にマイページにリダイレクトされる' do
+      # ログインページにアクセス
+      get new_user_session_path
+      expect(response).to have_http_status(:success)
+
+      # ログイン処理
+      post user_session_path, params: {
+        user: {
+          email: user.email,
+          password: user.password
+        }
+      }
+
+      # マイページにリダイレクトされることを確認
+      expect(response).to redirect_to(users_mypage_path)
+    end
+  end
+
+  describe 'POST /users' do
+    it 'サインアップ後にroot_pathにリダイレクトされる（confirmable有効のため）' do
+      # メールの送信をクリア
+      ActionMailer::Base.deliveries.clear
+
+      # サインアップ処理
+      post user_registration_path, params: {
+        user: {
+          name: '新規ユーザー',
+          email: 'newuser@example.com',
+          password: 'Password123',
+          password_confirmation: 'Password123'
+        }
+      }
+
+      # 確認メールが送信される前に、一旦root_pathにリダイレクトされる（confirmableのため）
+      expect(response).to redirect_to(root_path)
+    end
+  end
+end

--- a/webapp/spec/support/devise.rb
+++ b/webapp/spec/support/devise.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  config.include Devise::Test::IntegrationHelpers, type: :request
+  config.include Devise::Test::ControllerHelpers, type: :controller
+end

--- a/webapp/spec/system/homepage_spec.rb
+++ b/webapp/spec/system/homepage_spec.rb
@@ -10,6 +10,6 @@ RSpec.describe 'Application', type: :system do
 
   it 'can access the sign up page' do
     visit new_user_registration_path
-    expect(page).to have_content('Sign up')
+    expect(page).to have_content('新規登録')
   end
 end

--- a/webapp/spec/views/home/index.html.tailwindcss_spec.rb
+++ b/webapp/spec/views/home/index.html.tailwindcss_spec.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
-RSpec.describe "home/index.html.tailwindcss", type: :view do
+RSpec.describe 'home/index.html.tailwindcss', type: :view do
   pending "add some examples to (or delete) #{__FILE__}"
 end


### PR DESCRIPTION
## Issue 番号
- fixes #13 

## PR 概要
- 簡単なユーザ側マイページを作成。

## PR 詳細
### やったこと
- マイページの作成
  - ログイン後に遷移させる。
  - とりあえず基本情報を載せておく。
- テストの作成
  - 最低限。
- rubocop ルールの更新
  - 一部むしろ開発しづらくなりそうなルールを無効化

### やらなかったこと
- flash の導入
  - あとでやる。
- マイページの精査
  - めんどいのでやらない。

## 補足事項
- N/A
