### PR TITLE
ALB ヘルスチェック用のパスをつくる

### DIFF
--- a/webapp/app/controllers/health_check_controller.rb
+++ b/webapp/app/controllers/health_check_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# MEMO: 最も軽量にするべく、あえて ApplicationController を継承しない。
+
+# rubocop:disable Rails/ApplicationController
+class HealthCheckController < ActionController::Base
+  def index
+    render plain: 'OK', status: :ok
+  rescue StandardError => e
+    Rails.logger.error("Health check failed: #{e.message}")
+    render plain: 'ERROR', status: :service_unavailable
+  end
+end
+
+# rubocop:enable Rails/ApplicationController

--- a/webapp/config/routes.rb
+++ b/webapp/config/routes.rb
@@ -24,6 +24,9 @@ Rails.application.routes.draw do
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get 'up' => 'rails/health#show', as: :rails_health_check
 
+  # ALB health check endpoint
+  get 'health_check' => 'health_check#index'
+
   # Defines the root path route ("/")
   root 'home#index'
 end


### PR DESCRIPTION
## Issue 番号
- fixes #25 

## PR 概要
- ALB ヘルスチェック用のパスをつくる。

## PR 詳細
### やったこと
- /health_check path の追加
  - アクションは簡易に、200 OK を返すのみとする。
  - エラーを吐いた場合は 503 を返す。

### やらなかったこと
- テストの追加

## 補足事項
- N/A
