### PR TITLE
prod 環境への手動デプロイに必要な設定の追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,7 @@ EXPOSE 3000
 
 # アセットのプリコンパイル
 # Tailwind CSS などのビルドに必要
-ENV RAILS_ENV=production
-RUN bundle exec rails assets:precompile
+RUN RAILS_ENV=production bundle exec rails assets:precompile
 
 # Entrypoint スクリプトをコピーして実行権限を付与
 # pid ファイルの削除を行う

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,24 @@ FROM ruby:3.3.9
 
 WORKDIR /webapp
 
-# GemfileとGemfile.lockファイルを
-# イメージのwebappディレクトリ内にコピー
+# Gemfile とロックファイルだけを先にコピーして bundle install（キャッシュのため）
 COPY webapp/Gemfile* /webapp/
-
 RUN bundle install
+
+# Rails アプリ全体をコピー
+COPY webapp /webapp
 
 EXPOSE 3000
 
-CMD ["rails", "server", "-b", "0.0.0.0"]
+# アセットのプリコンパイル
+# Tailwind CSS などのビルドに必要
+ENV RAILS_ENV=production
+RUN bundle exec rails assets:precompile
+
+# Entrypoint スクリプトをコピーして実行権限を付与
+# pid ファイルの削除を行う
+COPY entrypoint.sh /usr/bin/
+RUN chmod +x /usr/bin/entrypoint.sh
+ENTRYPOINT ["entrypoint.sh"]
+
+CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+# Rails の server.pid を削除
+rm -f /webapp/tmp/pids/server.pid
+
+# 本来のコマンドを実行
+exec "$@"

--- a/webapp/config/environments/production.rb
+++ b/webapp/config/environments/production.rb
@@ -75,6 +75,21 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "webapp_production"
 
   config.action_mailer.perform_caching = false
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address: ENV.fetch('SMTP_HOST', 'localhost'),
+    port: 587,
+    user_name: ENV.fetch('SMTP_USERNAME', nil),
+    password: ENV.fetch('SMTP_PASSWORD', nil),
+    authentication: :login,
+    enable_starttls_auto: true
+  }
+
+  config.action_mailer.default_url_options = {
+    host: ENV.fetch('APP_HOST', 'example.com'),
+    protocol: 'https'
+  }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/webapp/config/environments/production.rb
+++ b/webapp/config/environments/production.rb
@@ -66,12 +66,8 @@ Rails.application.configure do
 
   # Use a different cache store in production.
   config.cache_store = :redis_cache_store, {
-    host: ENV.fetch('REDIS_HOST', 'localhost'),
-    port: ENV.fetch('REDIS_PORT', 6379),
-    db: ENV.fetch('REDIS_CACHE_DB', 1),
-    password: ENV.fetch('REDIS_PASSWORD', nil),
-    pool_size: ENV.fetch('REDIS_POOL_SIZE', 5).to_i,
-    pool_timeout: ENV.fetch('REDIS_POOL_TIMEOUT', 5).to_i
+    url: ENV.fetch("REDIS_URL", "redis://localhost:6379/1"),
+    ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
   }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).

--- a/webapp/config/environments/production.rb
+++ b/webapp/config/environments/production.rb
@@ -91,6 +91,9 @@ Rails.application.configure do
     protocol: 'https'
   }
 
+  config.action_mailer.default_options = { from: ENV.fetch('SENDER_ADDRESS', 'no-reply@example.com') }
+  config.mailer_sender = ENV.fetch('SENDER_ADDRESS', 'no-reply@example.com')
+
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false

--- a/webapp/config/environments/production.rb
+++ b/webapp/config/environments/production.rb
@@ -92,7 +92,6 @@ Rails.application.configure do
   }
 
   config.action_mailer.default_options = { from: ENV.fetch('SENDER_ADDRESS', 'no-reply@example.com') }
-  config.mailer_sender = ENV.fetch('SENDER_ADDRESS', 'no-reply@example.com')
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/webapp/config/initializers/devise.rb
+++ b/webapp/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = ENV.fetch('SENDER_ADDRESS', 'no-reply@example.com')
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
## Issue 番号
- fixes #21 

## PR 概要
- prod 環境へのデプロイに必要な作業を行う。

## PR 詳細
### やったこと
- Dockerfile の調整
  - `docker build` は compose.yml を参照しないため、copy などは Dockerfile 上で行う必要があった。
  - また、Rails Server 起動前に pid を削除する必要があるため entrypoint 経由でやる。
- 本番環境での Redis の接続、およびメール周りの設定
  - Redis は ElastiCache を使い、メールは SES の SMTP を使う。

### やらなかったこと
- dev 環境での docker compose build の正当性確認
  - prod に上げることを目標としているため、いったん成功ののち細かい部分を修正する予定。
- `$redis` の接続設定
  - いったん sidekiq や Rails のキャッシュ周りができていればなんとかなるので、あとでやる。
- リソース作成に関するドキュメント化（構成図含む）
  - つかれたのであとでやる。

## 補足事項
- 丸2日費やした。なかなか重い作業だった。
