### PR TITLE
既存のリソースを terraform 管理下に置く

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,9 @@
 
 #Ignore Redis files
 /data/*
+
+#Ignore terraform execution files
+/terraform/.terraform/*
+
+#Ignore terraform state files
+/terraform/scratch_state/*

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.14.0"
+  constraints = "6.14.0"
+  hashes = [
+    "h1:j08+AhqbMSg7/I4mMJCLB/uNJAcd85dNKLTxJ3z8rHo=",
+    "zh:35bd9514b397e96f40eaf5dea7de007e4105e804db3b246ee83edc31260f3251",
+    "zh:5662381971177f552b44b0f96e5aeb117b8c2e5c118845be41b19d44daed94d7",
+    "zh:58f574a0e83a2914c21995a159b155c0361c62690ebb8690cb28c1a5d9a40e6f",
+    "zh:798dc4a0bdd2da2e871a74f1c8fc64e30b5cd07e1d99255dc93c47dd202dc58b",
+    "zh:8972e3d0610e374f35f4e2f1ecd38ee6c4c0fa0d88bc88e0c138056646517751",
+    "zh:965711c26b0037842ab1a85a1ae38c11c446992b276131aea6fedd25995916bb",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b3c41e233c90d70d465b1e371e7b741d0ce67b7bcedabb87c3467b43c56727c0",
+    "zh:b518daff3eaa800e741103f16a7e2d99958bc3a9dc6a50f71d19dcfe7bcdee71",
+    "zh:bd26f8aecdffdbaab5b4dbe1d996a6bd1d6e53c8e036177f4daabaef8aa5abc3",
+    "zh:c5bf06ee484c693b763c90d3022f93c00e4e16b34c9e7c0440053efbc60b2ece",
+    "zh:d3ea9da36625b322745ec66652131c3f61367b0a7a1862308149e42e4bdf3d90",
+    "zh:d6ba44950eceb4d2ac404ace4260a89880cd0a7524a69191369939a8b7efe74c",
+    "zh:e263e3a5b41e92af5b05840bed8c03de3f8339c7d8ef8fbb21d3c700b31ff7ad",
+    "zh:f847e5db9c6361d6fc9b24c36a3c254c123c393b149c836d8fec6428a59824dd",
+  ]
+}

--- a/terraform/acm.tf
+++ b/terraform/acm.tf
@@ -1,0 +1,4 @@
+resource "aws_acm_certificate" "rails-test" {
+  domain_name       = "playground.campanule.dev"
+  validation_method = "DNS"
+}

--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -1,0 +1,66 @@
+resource "aws_lb" "rails-test" {
+  name               = "aws-rails-test-alb"
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = [aws_subnet.public_a.id, aws_subnet.public_c.id]
+
+  idle_timeout = 60
+}
+
+resource "aws_lb_target_group" "rails-test" {
+  name        = "aws-rails-test-target"
+  port        = 80
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = aws_vpc.aws-rails-test.id
+
+  health_check {
+    path                = "/up"
+    protocol            = "HTTP"
+    healthy_threshold   = 5
+    unhealthy_threshold = 2
+    interval            = 30
+    timeout             = 5
+  }
+}
+
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.rails-test.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-Res-PQ-2025-09"
+  # TODO: certificate_arn は手動で手に入れたうえで、あとで入れること。
+  # certificate_arn   = aws_acm_certificate_validation.rails-test.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.rails-test.arn
+
+    forward {
+      stickiness {
+        duration = 3600
+        enabled = false
+      }
+      target_group {
+        arn = aws_lb_target_group.rails-test.arn
+        weight = 1
+      }
+    }
+  }
+}
+
+resource "aws_lb_listener" "http_redirect" {
+  load_balancer_arn = aws_lb.rails-test.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}

--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -1,4 +1,4 @@
 resource "aws_cloudwatch_log_group" "ecs" {
   name              = "/ecs/aws-rails-test-task-def"
-  retention_in_days = 0
+  retention_in_days = 0 # 本番環境では 14 などの値にすること
 }

--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -1,0 +1,4 @@
+resource "aws_cloudwatch_log_group" "ecs" {
+  name              = "/ecs/aws-rails-test-task-def"
+  retention_in_days = 0
+}

--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -1,0 +1,13 @@
+resource "aws_ecr_repository" "rails-test" {
+  name = "aws-rails-test"
+
+  image_tag_mutability = "MUTABLE"
+
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+
+  image_scanning_configuration {
+    scan_on_push = false
+  }
+}

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -37,7 +37,7 @@ resource "aws_ecs_task_definition" "rails-test" {
   container_definitions = jsonencode([
     {
       name      = "webapp"
-      image     = "416000664814.dkr.ecr.ap-northeast-1.amazonaws.com/aws-rails-test:latest"
+      image     = "${aws_ecr_repository.rails-test.repository_url}:latest"
       essential = true
 
       portMappings = [
@@ -150,7 +150,7 @@ resource "aws_ecs_task_definition" "rails-test" {
       command = ["bundle", "exec", "sidekiq"]
       portMappings = []
       essential = false
-      image = "416000664814.dkr.ecr.ap-northeast-1.amazonaws.com/aws-rails-test:latest"
+      image = "${aws_ecr_repository.rails-test.repository_url}:latest"
 
       environment = [
         {

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -254,7 +254,7 @@ resource "aws_ecs_service" "rails-test" {
   name            = "aws-rails-test-task-def-service-gs84tbg4"
   cluster         = aws_ecs_cluster.rails-test.id
   task_definition = aws_ecs_task_definition.rails-test.arn
-  desired_count   = 1
+  desired_count   = 0 # TODO: 本番時には 1 にすること
   enable_ecs_managed_tags = true
   enable_execute_command = true
   health_check_grace_period_seconds = 0

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -1,0 +1,251 @@
+resource "aws_ecs_cluster" "rails-test" {
+  name = "aws-rails-test-ecs-cluster"
+
+  setting {
+    name  = "containerInsights"
+    value = "disabled"
+  }
+
+  configuration {
+    execute_command_configuration {
+      logging = "DEFAULT"
+    }
+  }
+}
+
+resource "aws_ecs_cluster_capacity_providers" "rails-test" {
+  cluster_name = aws_ecs_cluster.rails-test.name
+
+  capacity_providers = ["FARGATE", "FARGATE_SPOT"]
+}
+
+resource "aws_ecs_task_definition" "rails-test" {
+  family                   = "aws-rails-test-task-def"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "512"
+  memory                   = "1024"
+
+  execution_role_arn = aws_iam_role.ecs-task-execution.arn
+  task_role_arn      = aws_iam_role.secret-values.arn
+
+  runtime_platform {
+    cpu_architecture = "X86_64"
+    operating_system_family = "LINUX"
+  }
+
+  container_definitions = jsonencode([
+    {
+      name      = "webapp"
+      image     = "416000664814.dkr.ecr.ap-northeast-1.amazonaws.com/aws-rails-test:latest"
+      essential = true
+
+      portMappings = [
+        {
+          name = "rails-default-port"
+          appProtocol = "http"
+          hostPort = 3000
+          containerPort = 3000
+          protocol      = "tcp"
+        }
+      ]
+
+      environment = [
+        {
+          name  = "RAILS_ENV"
+          value = "production"
+        },
+        {
+          name  = "AWS_REGION"
+          value = "ap-northeast-1"
+        },
+        {
+          name  = "RAILS_LOG_TO_STDOUT"
+          value = "1"
+        },
+        {
+          name  = "RAILS_SERVE_STATIC_FILES"
+          value = "1"
+        },
+        {
+          name  = "REDIS_PORT"
+          value = "6379"
+        }
+      ]
+
+      secrets = [
+        {
+          name = "APP_HOST"
+          valueFrom = "${aws_secretsmanager_secret.rails-test.arn}:APP_HOST::"
+        },
+        {
+          name = "AWS_ACCESS_KEY_ID"
+          valueFrom = "${aws_secretsmanager_secret.rails-test.arn}:AWS_ACCESS_KEY_ID::"
+        },
+        {
+          name = "AWS_SECRET_ACCESS_KEY"
+          valueFrom = "${aws_secretsmanager_secret.rails-test.arn}:AWS_SECRET_ACCESS_KEY::"
+        },
+        {
+          name = "MYSQL_HOST"
+          valueFrom = "${aws_secretsmanager_secret.rails-test.arn}:MYSQL_HOST::"
+        },
+        {
+          name = "RAILS_MASTER_KEY"
+          valueFrom = "${aws_secretsmanager_secret.rails-test.arn}:RAILS_MASTER_KEY::"
+        },
+        {
+          name = "REDIS_HOST"
+          valueFrom = "${aws_secretsmanager_secret.rails-test.arn}:REDIS_HOST::"
+        },
+        {
+          name = "REDIS_URL"
+          valueFrom = "${aws_secretsmanager_secret.rails-test.arn}:REDIS_URL::"
+        },
+        {
+          name = "S3_BUCKET"
+          valueFrom = "${aws_secretsmanager_secret.rails-test.arn}:S3_BUCKET::"
+        },
+        {
+          name = "SENDER_ADDRESS"
+          valueFrom = "${aws_secretsmanager_secret.rails-test.arn}:SENDER_ADDRESS::"
+        },
+        {
+          name = "SMTP_HOST"
+          valueFrom = "${aws_secretsmanager_secret.rails-test.arn}:SMTP_HOST::"
+        },
+        {
+          name = "SMTP_USERNAME"
+          valueFrom = "${aws_secretsmanager_secret.rails-test.arn}:SMTP_USERNAME::"
+        },
+        {
+          name = "SMTP_PASSWORD"
+          valueFrom = "${aws_secretsmanager_secret.rails-test.arn}:SMTP_PASSWORD::"
+        },
+        {
+          name = "WEBAPP_DATABASE_PASSWORD"
+          valueFrom = "${aws_secretsmanager_secret.rails-test.arn}:WEBAPP_DATABASE_PASSWORD::"
+        }
+      ]
+
+      environmentFiles = []
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-create-group = "true"
+          awslogs-group = "/ecs/aws-rails-test-task-def"
+          awslogs-region = "ap-northeast-1"
+          awslogs-stream-prefix = "ecs"
+        }
+        secretOptions = []
+      }
+      mountPoints = []
+
+      systemControls = []
+      ulimits = []
+      volumesFrom = []
+    },
+    {
+      name = "worker"
+      command = ["bundle", "exec", "sidekiq"]
+      portMappings = []
+      essential = false
+      image = "416000664814.dkr.ecr.ap-northeast-1.amazonaws.com/aws-rails-test:latest"
+
+      environment = [
+        {
+          name  = "RAILS_ENV"
+          value = "production"
+        },
+        {
+          name  = "AWS_REGION"
+          value = "ap-northeast-1"
+        },
+        {
+          name  = "RAILS_LOG_TO_STDOUT"
+          value = "1"
+        },
+        {
+          name  = "RAILS_SERVE_STATIC_FILES"
+          value = "1"
+        },
+        {
+          name  = "REDIS_PORT"
+          value = "6379"
+        }
+      ]
+
+      secrets = [
+        {
+          name = "APP_HOST"
+          valueFrom = "${aws_secretsmanager_secret.rails-test.arn}:APP_HOST::"
+        },
+        {
+          name = "AWS_ACCESS_KEY_ID"
+          valueFrom = "${aws_secretsmanager_secret.rails-test.arn}:AWS_ACCESS_KEY_ID::"
+        },
+        {
+          name = "AWS_SECRET_ACCESS_KEY"
+          valueFrom = "${aws_secretsmanager_secret.rails-test.arn}:AWS_SECRET_ACCESS_KEY::"
+        },
+        {
+          name = "MYSQL_HOST"
+          valueFrom = "${aws_secretsmanager_secret.rails-test.arn}:MYSQL_HOST::"
+        },
+        {
+          name = "RAILS_MASTER_KEY"
+          valueFrom = "${aws_secretsmanager_secret.rails-test.arn}:RAILS_MASTER_KEY::"
+        },
+        {
+          name = "REDIS_HOST"
+          valueFrom = "${aws_secretsmanager_secret.rails-test.arn}:REDIS_HOST::"
+        },
+        {
+          name = "REDIS_URL"
+          valueFrom = "${aws_secretsmanager_secret.rails-test.arn}:REDIS_URL::"
+        },
+        {
+          name = "S3_BUCKET"
+          valueFrom = "${aws_secretsmanager_secret.rails-test.arn}:S3_BUCKET::"
+        },
+        {
+          name = "SENDER_ADDRESS"
+          valueFrom = "${aws_secretsmanager_secret.rails-test.arn}:SENDER_ADDRESS::"
+        },
+        {
+          name = "SMTP_HOST"
+          valueFrom = "${aws_secretsmanager_secret.rails-test.arn}:SMTP_HOST::"
+        },
+        {
+          name = "SMTP_USERNAME"
+          valueFrom = "${aws_secretsmanager_secret.rails-test.arn}:SMTP_USERNAME::"
+        },
+        {
+          name = "SMTP_PASSWORD"
+          valueFrom = "${aws_secretsmanager_secret.rails-test.arn}:SMTP_PASSWORD::"
+        },
+        {
+          name = "WEBAPP_DATABASE_PASSWORD"
+          valueFrom = "${aws_secretsmanager_secret.rails-test.arn}:WEBAPP_DATABASE_PASSWORD::"
+        }
+      ]
+
+      environmentFiles = []
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-create-group = "true"
+          awslogs-group = "/ecs/aws-rails-test-task-def"
+          awslogs-region = "ap-northeast-1"
+          awslogs-stream-prefix = "ecs"
+        }
+        secretOptions = []
+      }
+      mountPoints = []
+
+      systemControls = []
+      volumesFrom = []
+    }
+  ])
+}

--- a/terraform/eip.tf
+++ b/terraform/eip.tf
@@ -1,3 +1,5 @@
 resource "aws_eip" "nat" {
-
+  tags = {
+    Name = "aws-rails-test-nat-eip"
+  }
 }

--- a/terraform/eip.tf
+++ b/terraform/eip.tf
@@ -1,0 +1,3 @@
+resource "aws_eip" "nat" {
+
+}

--- a/terraform/elasticache.tf
+++ b/terraform/elasticache.tf
@@ -1,0 +1,36 @@
+resource "aws_elasticache_subnet_group" "valkey" {
+  name       = "aws-rails-test-subnet-group-valkey"
+  description = " "
+  subnet_ids = [
+    aws_subnet.private_a.id,
+    aws_subnet.private_c.id,
+  ]
+}
+
+resource "aws_elasticache_replication_group" "valkey" {
+  replication_group_id          = "aws-rails-test-valkey-cluster"
+  description = " "
+  apply_immediately = false
+  auto_minor_version_upgrade = "true"
+  cluster_mode = "disabled"
+
+  engine         = "valkey"
+  engine_version = "7.2"
+
+  node_type = "cache.t4g.micro"
+
+  subnet_group_name  = aws_elasticache_subnet_group.valkey.name
+  security_group_ids = [aws_security_group.elasticache.id]
+
+  port = 6379
+
+  at_rest_encryption_enabled   = true
+  transit_encryption_enabled   = true
+
+  automatic_failover_enabled = true
+  multi_az_enabled           = true
+
+  parameter_group_name = "default.valkey7"
+
+  snapshot_retention_limit = 0
+}

--- a/terraform/elasticache.tf
+++ b/terraform/elasticache.tf
@@ -1,6 +1,6 @@
 resource "aws_elasticache_subnet_group" "valkey" {
   name       = "aws-rails-test-subnet-group-valkey"
-  description = " "
+  description = "Subnet group for Valkey cluster"
   subnet_ids = [
     aws_subnet.private_a.id,
     aws_subnet.private_c.id,
@@ -9,7 +9,7 @@ resource "aws_elasticache_subnet_group" "valkey" {
 
 resource "aws_elasticache_replication_group" "valkey" {
   replication_group_id          = "aws-rails-test-valkey-cluster"
-  description = " "
+  description = "Valkey cluster for Rails test application"
   apply_immediately = false
   auto_minor_version_upgrade = "true"
   cluster_mode = "disabled"
@@ -32,5 +32,5 @@ resource "aws_elasticache_replication_group" "valkey" {
 
   parameter_group_name = "default.valkey7"
 
-  snapshot_retention_limit = 0
+  snapshot_retention_limit = 0 # 本番環境では 1-7 などの値にすること
 }

--- a/terraform/iam_oidc.tf
+++ b/terraform/iam_oidc.tf
@@ -1,0 +1,12 @@
+resource "aws_iam_openid_connect_provider" "github-actions" {
+  url = "https://token.actions.githubusercontent.com"
+
+  client_id_list = [
+    "sts.amazonaws.com"
+  ]
+
+  # GitHub Actions の OIDC 固有値（固定）
+  thumbprint_list = [
+    "2b18947a6a9fc7764fd8b5fb18a863b0c6dac24f"
+  ]
+}

--- a/terraform/iam_policy.tf
+++ b/terraform/iam_policy.tf
@@ -1,0 +1,91 @@
+resource "aws_iam_policy" "ecs-exec" {
+  name        = "enable-ecs-exec"
+
+  policy = jsonencode({
+    Statement = [
+      {
+        Action = [
+          "ssmmessages:CreateControlChannel",
+          "ssmmessages:CreateDataChannel",
+          "ssmmessages:OpenControlChannel",
+          "ssmmessages:OpenDataChannel",
+        ]
+        Effect = "Allow"
+        Resource = "*"
+      },
+    ]
+    Version = "2012-10-17"
+  })
+  tags = {}
+}
+
+resource "aws_iam_policy" "secret-values" {
+  name        = "get-secret-values"
+
+  policy = jsonencode({
+    Statement = [
+      {
+        Action = [
+          "secretsmanager:GetSecretValue",
+        ]
+        Effect = "Allow"
+        Resource = "arn:aws:secretsmanager:ap-northeast-1:416000664814:secret:aws-rails-test-secrets-higJwm"
+      },
+    ]
+    Version = "2012-10-17"
+  })
+  tags = {}
+}
+
+resource "aws_iam_policy" "s3" {
+  name        = "aws-rails-s3"
+
+  policy = jsonencode({
+    Statement = [
+      {
+        Action = [
+          "s3:PutObject",
+          "s3:GetObject",
+          "s3:ListBucket",
+          "s3:DeleteObject",
+          "s3:PutObjectAcl",
+        ]
+        Effect = "Allow"
+        Resource = [
+          "arn:aws:s3:::haya10-s3-test-bucket-r03v/*",
+          "arn:aws:s3:::haya10-s3-test-bucket-r03v",
+        ]
+        Sid = "VisualEditor0"
+      },
+    ]
+    Version = "2012-10-17"
+  })
+  tags = {}
+}
+
+resource "aws_iam_policy" "github-actions" {
+  name        = "ecr-github-actions-test"
+
+  policy = jsonencode({
+    Statement = [
+      {
+        Action = "ecr:GetAuthorizationToken"
+        Effect = "Allow"
+        Resource = "*"
+      },
+      {
+        Action = [
+          "ecr:UploadLayerPart",
+          "ecr:PutImage",
+          "ecr:InitiateLayerUpload",
+          "ecr:CompleteLayerUpload",
+          "ecr:BatchCheckLayerAvailability",
+        ]
+        Effect = "Allow"
+        Resource = "arn:aws:ecr:ap-northeast-1:416000664814:repository/aws-rails-test"
+      }
+    ]
+    Version = "2012-10-17"
+  })
+  tags = {}
+}

--- a/terraform/iam_policy.tf
+++ b/terraform/iam_policy.tf
@@ -29,7 +29,7 @@ resource "aws_iam_policy" "secret-values" {
           "secretsmanager:GetSecretValue",
         ]
         Effect = "Allow"
-        Resource = "arn:aws:secretsmanager:ap-northeast-1:416000664814:secret:aws-rails-test-secrets-higJwm"
+        Resource = aws_secretsmanager_secret.rails-test.arn
       },
     ]
     Version = "2012-10-17"
@@ -52,8 +52,8 @@ resource "aws_iam_policy" "s3" {
         ]
         Effect = "Allow"
         Resource = [
-          "arn:aws:s3:::haya10-s3-test-bucket-r03v/*",
-          "arn:aws:s3:::haya10-s3-test-bucket-r03v",
+          "${aws_s3_bucket.rails-test.arn}/*",
+          aws_s3_bucket.rails-test.arn,
         ]
         Sid = "VisualEditor0"
       },
@@ -82,7 +82,7 @@ resource "aws_iam_policy" "github-actions" {
           "ecr:BatchCheckLayerAvailability",
         ]
         Effect = "Allow"
-        Resource = "arn:aws:ecr:ap-northeast-1:416000664814:repository/aws-rails-test"
+        Resource = aws_ecr_repository.rails-test.arn
       }
     ]
     Version = "2012-10-17"

--- a/terraform/iam_role.tf
+++ b/terraform/iam_role.tf
@@ -1,7 +1,3 @@
-# __generated__ by Terraform
-# Please review these resources and move them into your main configuration files.
-
-# __generated__ by Terraform
 resource "aws_iam_role" "ecs-task-execution" {
   provider = aws
   assume_role_policy = jsonencode({
@@ -25,15 +21,6 @@ resource "aws_iam_role" "ecs-task-execution" {
   tags_all              = {}
 }
 
-import {
-  to       = aws_iam_role.ecs-task-execution
-  provider = aws
-  identity = {
-    account_id = "416000664814"
-    name       = "ecsTaskExecutionRole"
-  }
-}
-
 resource "aws_iam_role" "secret-values" {
   provider = aws
   assume_role_policy = jsonencode({
@@ -55,15 +42,6 @@ resource "aws_iam_role" "secret-values" {
   permissions_boundary  = null
   tags                  = {}
   tags_all              = {}
-}
-
-import {
-  to       = aws_iam_role.secret-values
-  provider = aws
-  identity = {
-    account_id = "416000664814"
-    name       = "get-secret-values-for-ecs"
-  }
 }
 
 resource "aws_iam_role" "oidc" {
@@ -95,15 +73,6 @@ resource "aws_iam_role" "oidc" {
   tags_all              = {}
 }
 
-import {
-  to       = aws_iam_role.oidc
-  provider = aws
-  identity = {
-    account_id = "416000664814"
-    name       = "github-actions-oidc-test"
-  }
-}
-
 resource "aws_iam_role" "rds-monitoring" {
   provider = aws
   assume_role_policy = jsonencode({
@@ -125,13 +94,4 @@ resource "aws_iam_role" "rds-monitoring" {
   permissions_boundary  = null
   tags                  = {}
   tags_all              = {}
-}
-
-import {
-  to       = aws_iam_role.rds-monitoring
-  provider = aws
-  identity = {
-    account_id = "416000664814"
-    name       = "rds-monitoring-role"
-  }
 }

--- a/terraform/iam_role.tf
+++ b/terraform/iam_role.tf
@@ -11,14 +11,10 @@ resource "aws_iam_role" "ecs-task-execution" {
     }]
     Version = "2008-10-17"
   })
-  description           = null
-  force_detach_policies = null
+  description           = "Allows ECS services to execute tasks."
   max_session_duration  = 3600
   name                  = "ecsTaskExecutionRole"
   path                  = "/"
-  permissions_boundary  = null
-  tags                  = {}
-  tags_all              = {}
 }
 
 resource "aws_iam_role" "secret-values" {
@@ -35,13 +31,9 @@ resource "aws_iam_role" "secret-values" {
     Version = "2012-10-17"
   })
   description           = "Allows ECS tasks to call AWS services on your behalf."
-  force_detach_policies = null
   max_session_duration  = 3600
   name                  = "get-secret-values-for-ecs"
   path                  = "/"
-  permissions_boundary  = null
-  tags                  = {}
-  tags_all              = {}
 }
 
 resource "aws_iam_role" "oidc" {
@@ -63,14 +55,10 @@ resource "aws_iam_role" "oidc" {
     }]
     Version = "2012-10-17"
   })
-  description           = null
-  force_detach_policies = null
+  description           = "Allows GitHub Actions OIDC."
   max_session_duration  = 3600
   name                  = "github-actions-oidc-test"
   path                  = "/"
-  permissions_boundary  = null
-  tags                  = {}
-  tags_all              = {}
 }
 
 resource "aws_iam_role" "rds-monitoring" {
@@ -86,12 +74,8 @@ resource "aws_iam_role" "rds-monitoring" {
     }]
     Version = "2012-10-17"
   })
-  description           = null
-  force_detach_policies = null
+  description           = "Allows monitoring RDS."
   max_session_duration  = 3600
   name                  = "rds-monitoring-role"
   path                  = "/"
-  permissions_boundary  = null
-  tags                  = {}
-  tags_all              = {}
 }

--- a/terraform/iam_role.tf
+++ b/terraform/iam_role.tf
@@ -79,7 +79,7 @@ resource "aws_iam_role" "oidc" {
       }
       Effect = "Allow"
       Principal = {
-        Federated = "arn:aws:iam::416000664814:oidc-provider/token.actions.githubusercontent.com"
+        Federated = aws_iam_openid_connect_provider.github-actions.arn
       }
       Sid = ""
     }]

--- a/terraform/iam_role.tf
+++ b/terraform/iam_role.tf
@@ -1,0 +1,137 @@
+# __generated__ by Terraform
+# Please review these resources and move them into your main configuration files.
+
+# __generated__ by Terraform
+resource "aws_iam_role" "ecs-task-execution" {
+  provider = aws
+  assume_role_policy = jsonencode({
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "ecs-tasks.amazonaws.com"
+      }
+      Sid = ""
+    }]
+    Version = "2008-10-17"
+  })
+  description           = null
+  force_detach_policies = null
+  max_session_duration  = 3600
+  name                  = "ecsTaskExecutionRole"
+  path                  = "/"
+  permissions_boundary  = null
+  tags                  = {}
+  tags_all              = {}
+}
+
+import {
+  to       = aws_iam_role.ecs-task-execution
+  provider = aws
+  identity = {
+    account_id = "416000664814"
+    name       = "ecsTaskExecutionRole"
+  }
+}
+
+resource "aws_iam_role" "secret-values" {
+  provider = aws
+  assume_role_policy = jsonencode({
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "ecs-tasks.amazonaws.com"
+      }
+      Sid = ""
+    }]
+    Version = "2012-10-17"
+  })
+  description           = "Allows ECS tasks to call AWS services on your behalf."
+  force_detach_policies = null
+  max_session_duration  = 3600
+  name                  = "get-secret-values-for-ecs"
+  path                  = "/"
+  permissions_boundary  = null
+  tags                  = {}
+  tags_all              = {}
+}
+
+import {
+  to       = aws_iam_role.secret-values
+  provider = aws
+  identity = {
+    account_id = "416000664814"
+    name       = "get-secret-values-for-ecs"
+  }
+}
+
+resource "aws_iam_role" "oidc" {
+  provider = aws
+  assume_role_policy = jsonencode({
+    Statement = [{
+      Action = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = {
+          "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          "token.actions.githubusercontent.com:sub" = "repo:Haya10-y/aws-rails-practice:ref:refs/heads/production"
+        }
+      }
+      Effect = "Allow"
+      Principal = {
+        Federated = "arn:aws:iam::416000664814:oidc-provider/token.actions.githubusercontent.com"
+      }
+      Sid = ""
+    }]
+    Version = "2012-10-17"
+  })
+  description           = null
+  force_detach_policies = null
+  max_session_duration  = 3600
+  name                  = "github-actions-oidc-test"
+  path                  = "/"
+  permissions_boundary  = null
+  tags                  = {}
+  tags_all              = {}
+}
+
+import {
+  to       = aws_iam_role.oidc
+  provider = aws
+  identity = {
+    account_id = "416000664814"
+    name       = "github-actions-oidc-test"
+  }
+}
+
+resource "aws_iam_role" "rds-monitoring" {
+  provider = aws
+  assume_role_policy = jsonencode({
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "monitoring.rds.amazonaws.com"
+      }
+      Sid = ""
+    }]
+    Version = "2012-10-17"
+  })
+  description           = null
+  force_detach_policies = null
+  max_session_duration  = 3600
+  name                  = "rds-monitoring-role"
+  path                  = "/"
+  permissions_boundary  = null
+  tags                  = {}
+  tags_all              = {}
+}
+
+import {
+  to       = aws_iam_role.rds-monitoring
+  provider = aws
+  identity = {
+    account_id = "416000664814"
+    name       = "rds-monitoring-role"
+  }
+}

--- a/terraform/iam_role_policy_attachment.tf
+++ b/terraform/iam_role_policy_attachment.tf
@@ -1,0 +1,39 @@
+resource "aws_iam_role_policy_attachment" "secret-values-secret-values" {
+  role       = aws_iam_role.secret-values.name
+  policy_arn = aws_iam_policy.secret-values.arn
+}
+
+resource "aws_iam_role_policy_attachment" "secret-values-ecs-exec" {
+  role       = aws_iam_role.secret-values.name
+  policy_arn = aws_iam_policy.ecs-exec.arn
+}
+
+resource "aws_iam_role_policy_attachment" "ecs-task-execution-secret-values" {
+  role       = aws_iam_role.ecs-task-execution.name
+  policy_arn = aws_iam_policy.secret-values.arn
+}
+
+resource "aws_iam_role_policy_attachment" "ecs-task-execution-ecs-exec" {
+  role       = aws_iam_role.ecs-task-execution.name
+  policy_arn = aws_iam_policy.ecs-exec.arn
+}
+
+resource "aws_iam_role_policy_attachment" "ecs-task-execution-role-policy" {
+  role       = aws_iam_role.ecs-task-execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "oidc-github-actions" {
+  role       = aws_iam_role.oidc.name
+  policy_arn = aws_iam_policy.github-actions.arn
+}
+
+resource "aws_iam_role_policy_attachment" "oidc-s3-readonly" {
+  role       = aws_iam_role.oidc.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "rds-monitoring-role-policy" {
+  role       = aws_iam_role.rds-monitoring.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
+}

--- a/terraform/igw.tf
+++ b/terraform/igw.tf
@@ -1,0 +1,7 @@
+resource "aws_internet_gateway" "aws-rails-test" {
+  vpc_id = aws_vpc.aws-rails-test.id
+
+  tags = {
+    Name = "aws-rails-test-igw"
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -6,8 +6,12 @@ terraform {
     }
   }
 
-  backend "local" {
-    path = "./scratch_state/terraform.tfstate"
+  backend "s3" {
+    bucket = "haya10-tfstate-bucket-h2af"
+    key    = "terraform/terraform.tfstate"
+    region = "ap-northeast-1"
+    profile = "terraform"
+    encrypt = true
   }
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "6.14.0"
+    }
+  }
+
+  backend "local" {
+    path = "./scratch_state/terraform.tfstate"
+  }
+}
+
+provider "aws" {
+  region = "ap-northeast-1"
+  profile = "terraform"
+}

--- a/terraform/main.tfquery.hcl
+++ b/terraform/main.tfquery.hcl
@@ -1,0 +1,3 @@
+list "aws_iam_role" "main" {
+  provider = aws
+}

--- a/terraform/main.tfquery.hcl
+++ b/terraform/main.tfquery.hcl
@@ -1,3 +1,0 @@
-list "aws_iam_role" "main" {
-  provider = aws
-}

--- a/terraform/nat.tf
+++ b/terraform/nat.tf
@@ -1,0 +1,8 @@
+resource "aws_nat_gateway" "aws-rails-test" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = aws_subnet.public_a.id
+
+  tags = {
+    Name = "aws-rails-test-nat-gateway"
+  }
+}

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -1,6 +1,6 @@
 resource "aws_db_subnet_group" "rails-test" {
   name       = "default-vpc-00204fb854441d3f4"
-  description= "Created from the RDS Management Console"
+  description= "DB subnet group for Rails test application"
   subnet_ids = [
     aws_subnet.public_a.id,
     aws_subnet.public_c.id,
@@ -32,7 +32,7 @@ resource "aws_db_instance" "rails-test" {
   parameter_group_name = "default.mysql8.4"
   option_group_name    = "default:mysql-8-4"
 
-  backup_retention_period = 0
+  backup_retention_period = 0 # 本番環境では 7 などの値にすること
   copy_tags_to_snapshot = true
 
   auto_minor_version_upgrade = true

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -1,0 +1,49 @@
+resource "aws_db_subnet_group" "rails-test" {
+  name       = "default-vpc-00204fb854441d3f4"
+  description= "Created from the RDS Management Console"
+  subnet_ids = [
+    aws_subnet.public_a.id,
+    aws_subnet.public_c.id,
+    aws_subnet.private_a.id,
+    aws_subnet.private_c.id,
+  ]
+}
+
+resource "aws_db_instance" "rails-test" {
+  identifier = "aws-rails-test-rds"
+
+  engine            = "mysql"
+  engine_version    = "8.4.7"
+  instance_class    = "db.t4g.micro"
+  allocated_storage = 20
+  max_allocated_storage = 1000
+  apply_immediately = false
+
+  username = "admin"
+
+  db_subnet_group_name = aws_db_subnet_group.rails-test.name
+
+  vpc_security_group_ids = [
+    aws_security_group.rds.id
+  ]
+
+  multi_az = true
+
+  parameter_group_name = "default.mysql8.4"
+  option_group_name    = "default:mysql-8-4"
+
+  backup_retention_period = 0
+  copy_tags_to_snapshot = true
+
+  auto_minor_version_upgrade = true
+
+  performance_insights_enabled = false
+
+  monitoring_interval = 0
+
+  storage_encrypted = true
+
+  deletion_protection = false
+
+  skip_final_snapshot = true
+}

--- a/terraform/route.tf
+++ b/terraform/route.tf
@@ -15,17 +15,3 @@ resource "aws_route" "private_c_default" {
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = aws_nat_gateway.aws-rails-test.id
 }
-
-# ERROR: あらかじめ指定されている vpc_endpoint_id だと動かない模様。
-#        一旦 gateway_id で置くが、だいぶ怖い…
-resource "aws_route" "private_a_s3" {
-  route_table_id         = aws_route_table.private_a.id
-  gateway_id        = aws_vpc_endpoint.s3.id
-  destination_prefix_list_id = "pl-61a54008"
-}
-
-resource "aws_route" "private_c_s3" {
-  route_table_id         = aws_route_table.private_c.id
-  gateway_id        = aws_vpc_endpoint.s3.id
-  destination_prefix_list_id = "pl-61a54008"
-}

--- a/terraform/route.tf
+++ b/terraform/route.tf
@@ -1,0 +1,31 @@
+resource "aws_route" "public_default" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.aws-rails-test.id
+}
+
+resource "aws_route" "private_a_default" {
+  route_table_id         = aws_route_table.private_a.id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.aws-rails-test.id
+}
+
+resource "aws_route" "private_c_default" {
+  route_table_id         = aws_route_table.private_c.id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.aws-rails-test.id
+}
+
+# ERROR: あらかじめ指定されている vpc_endpoint_id だと動かない模様。
+#        一旦 gateway_id で置くが、だいぶ怖い…
+resource "aws_route" "private_a_s3" {
+  route_table_id         = aws_route_table.private_a.id
+  gateway_id        = aws_vpc_endpoint.s3.id
+  destination_prefix_list_id = "pl-61a54008"
+}
+
+resource "aws_route" "private_c_s3" {
+  route_table_id         = aws_route_table.private_c.id
+  gateway_id        = aws_vpc_endpoint.s3.id
+  destination_prefix_list_id = "pl-61a54008"
+}

--- a/terraform/rtb.tf
+++ b/terraform/rtb.tf
@@ -1,0 +1,23 @@
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.aws-rails-test.id
+
+  tags = {
+    Name = "aws-rails-test-rtb-public"
+  }
+}
+
+resource "aws_route_table" "private_a" {
+  vpc_id = aws_vpc.aws-rails-test.id
+
+  tags = {
+    Name = "aws-rails-test-rtb-private1-ap-northeast-1a"
+  }
+}
+
+resource "aws_route_table" "private_c" {
+  vpc_id = aws_vpc.aws-rails-test.id
+
+  tags = {
+    Name = "aws-rails-test-rtb-private2-ap-northeast-1c"
+  }
+}

--- a/terraform/rtb_association.tf
+++ b/terraform/rtb_association.tf
@@ -1,0 +1,19 @@
+resource "aws_route_table_association" "public_a" {
+  subnet_id      = aws_subnet.public_a.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "public_c" {
+  subnet_id      = aws_subnet.public_c.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "private_a" {
+  subnet_id      = aws_subnet.private_a.id
+  route_table_id = aws_route_table.private_a.id
+}
+
+resource "aws_route_table_association" "private_c" {
+  subnet_id      = aws_subnet.private_c.id
+  route_table_id = aws_route_table.private_c.id
+}

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -1,0 +1,37 @@
+resource "aws_s3_bucket" "rails-test" {
+  bucket = "haya10-s3-test-bucket-r03v"
+
+  tags = {}
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "rails-test" {
+  bucket = aws_s3_bucket.rails-test.id
+
+  rule {
+    bucket_key_enabled = true
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_cors_configuration" "rails-test" {
+  bucket = aws_s3_bucket.rails-test.id
+
+  cors_rule {
+    allowed_methods = ["PUT"]
+    allowed_origins = ["http://localhost:3000"]
+    allowed_headers = ["Content-Type", "Content-MD5", "Content-Disposition"]
+    expose_headers  = []
+    max_age_seconds = 3600
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "rails-test" {
+  bucket = aws_s3_bucket.rails-test.id
+
+  block_public_acls       = false
+  block_public_policy     = true
+  ignore_public_acls      = false
+  restrict_public_buckets = true
+}

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -30,8 +30,8 @@ resource "aws_s3_bucket_cors_configuration" "rails-test" {
 resource "aws_s3_bucket_public_access_block" "rails-test" {
   bucket = aws_s3_bucket.rails-test.id
 
-  block_public_acls       = false
+  block_public_acls       = true
   block_public_policy     = true
-  ignore_public_acls      = false
+  ignore_public_acls      = true
   restrict_public_buckets = true
 }

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -1,7 +1,5 @@
 resource "aws_s3_bucket" "rails-test" {
   bucket = "haya10-s3-test-bucket-r03v"
-
-  tags = {}
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "rails-test" {

--- a/terraform/secrets_manager.tf
+++ b/terraform/secrets_manager.tf
@@ -1,0 +1,3 @@
+resource "aws_secretsmanager_secret" "rails-test" {
+  name = "aws-rails-test-secrets"
+}

--- a/terraform/sg.tf
+++ b/terraform/sg.tf
@@ -1,0 +1,127 @@
+resource "aws_security_group" "rds" {
+  name        = "aws-rails-test-rds-sg"
+  description = "aws-rails-test-rds-sg"
+  vpc_id      = aws_vpc.aws-rails-test.id
+
+  ingress = [
+    {
+      description = "default-mysql-port"
+      cidr_blocks = []
+      from_port = 3306
+      to_port = 3306
+      protocol = "tcp"
+      ipv6_cidr_blocks = []
+      prefix_list_ids = []
+      security_groups = [aws_security_group.ecs.id]
+      self = false
+    }
+  ]
+  egress  = []
+}
+
+resource "aws_security_group" "elasticache" {
+  name        = "aws-rails-test-elasticache-sg"
+  description = "aws-rails-test-elasticache-sg"
+  vpc_id      = aws_vpc.aws-rails-test.id
+
+  ingress = [
+    {
+      description = ""
+      cidr_blocks = []
+      from_port = 6379
+      to_port = 6379
+      protocol = "tcp"
+      ipv6_cidr_blocks = []
+      prefix_list_ids = []
+      security_groups = [aws_security_group.ecs.id]
+      self = false
+    }
+  ]
+  egress  = []
+}
+
+resource "aws_security_group" "alb" {
+  name        = "aws-rails-test-alb-sg"
+  description = "aws-rails-test-alb-sg"
+  vpc_id      = aws_vpc.aws-rails-test.id
+
+  ingress = [
+    {
+      description = ""
+      cidr_blocks = ["0.0.0.0/0"]
+      from_port = 80
+      to_port = 80
+      protocol = "tcp"
+      ipv6_cidr_blocks = []
+      prefix_list_ids = []
+      security_groups = []
+      self = false
+    },
+    {
+      description = ""
+      cidr_blocks = ["0.0.0.0/0"]
+      from_port = 443
+      to_port = 443
+      protocol = "tcp"
+      ipv6_cidr_blocks = []
+      prefix_list_ids = []
+      security_groups = []
+      self = false
+    }
+  ]
+  egress  = []
+}
+
+resource "aws_security_group" "ecs-exec" {
+  name        = "ecs-exec-sg"
+  description = "allow ecs exec"
+  vpc_id      = aws_vpc.aws-rails-test.id
+
+  ingress = [
+    {
+      description = ""
+      cidr_blocks = []
+      from_port = 443
+      to_port = 443
+      protocol = "tcp"
+      ipv6_cidr_blocks = []
+      prefix_list_ids = []
+      security_groups = [aws_security_group.ecs.id]
+      self = false
+    }
+  ]
+  egress  = [
+    {
+      description = ""
+      cidr_blocks = ["0.0.0.0/0"]
+      from_port = 0
+      to_port = 0
+      protocol = "-1"
+      ipv6_cidr_blocks = []
+      prefix_list_ids = []
+      security_groups = []
+      self = false
+    }
+  ]
+}
+
+resource "aws_security_group" "ecs" {
+  name        = "aws-rails-test-ecs-sg"
+  description = "aws-rails-test-ecs-sg"
+  vpc_id      = aws_vpc.aws-rails-test.id
+
+  ingress = [
+    {
+      description = "default-rails-port"
+      cidr_blocks = ["0.0.0.0/0"]
+      from_port = 3000
+      to_port = 3000
+      protocol = "tcp"
+      ipv6_cidr_blocks = []
+      prefix_list_ids = []
+      security_groups = []
+      self = false
+    }
+  ]
+  egress  = []
+}

--- a/terraform/sg.tf
+++ b/terraform/sg.tf
@@ -18,7 +18,7 @@ resource "aws_security_group" "rds" {
   ]
   egress  = [
     {
-      description = " "
+      description = "Allow all outbound traffic"
       ipv6_cidr_blocks = []
       prefix_list_ids = []
       security_groups = []
@@ -38,7 +38,7 @@ resource "aws_security_group" "elasticache" {
 
   ingress = [
     {
-      description = ""
+      description = "Allow only ECS security group for Redis port"
       cidr_blocks = []
       from_port = 6379
       to_port = 6379
@@ -51,7 +51,7 @@ resource "aws_security_group" "elasticache" {
   ]
   egress  = [
     {
-      description = " "
+      description = "Allow all outbound traffic"
       ipv6_cidr_blocks = []
       prefix_list_ids = []
       security_groups = []
@@ -71,7 +71,7 @@ resource "aws_security_group" "alb" {
 
   ingress = [
     {
-      description = ""
+      description = "Allow all HTTP traffic"
       cidr_blocks = ["0.0.0.0/0"]
       from_port = 80
       to_port = 80
@@ -82,7 +82,7 @@ resource "aws_security_group" "alb" {
       self = false
     },
     {
-      description = ""
+      description = "Allow all HTTPS traffic"
       cidr_blocks = ["0.0.0.0/0"]
       from_port = 443
       to_port = 443
@@ -95,7 +95,7 @@ resource "aws_security_group" "alb" {
   ]
   egress  = [
     {
-      description = " "
+      description = "Allow all outbound traffic"
       ipv6_cidr_blocks = []
       prefix_list_ids = []
       security_groups = []
@@ -115,7 +115,7 @@ resource "aws_security_group" "ecs-exec" {
 
   ingress = [
     {
-      description = ""
+      description = "Allow all HTTPS traffic"
       cidr_blocks = []
       from_port = 443
       to_port = 443
@@ -128,7 +128,7 @@ resource "aws_security_group" "ecs-exec" {
   ]
   egress  = [
     {
-      description = ""
+      description = "Allow all outbound traffic"
       cidr_blocks = ["0.0.0.0/0"]
       from_port = 0
       to_port = 0
@@ -161,7 +161,7 @@ resource "aws_security_group" "ecs" {
   ]
   egress  = [
     {
-      description = " "
+      description = "Allow all outbound traffic"
       ipv6_cidr_blocks = []
       prefix_list_ids = []
       security_groups = []

--- a/terraform/sg.tf
+++ b/terraform/sg.tf
@@ -16,7 +16,19 @@ resource "aws_security_group" "rds" {
       self = false
     }
   ]
-  egress  = []
+  egress  = [
+    {
+      description = " "
+      ipv6_cidr_blocks = []
+      prefix_list_ids = []
+      security_groups = []
+      self = false
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+  ]
 }
 
 resource "aws_security_group" "elasticache" {
@@ -37,7 +49,19 @@ resource "aws_security_group" "elasticache" {
       self = false
     }
   ]
-  egress  = []
+  egress  = [
+    {
+      description = " "
+      ipv6_cidr_blocks = []
+      prefix_list_ids = []
+      security_groups = []
+      self = false
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+  ]
 }
 
 resource "aws_security_group" "alb" {
@@ -69,7 +93,19 @@ resource "aws_security_group" "alb" {
       self = false
     }
   ]
-  egress  = []
+  egress  = [
+    {
+      description = " "
+      ipv6_cidr_blocks = []
+      prefix_list_ids = []
+      security_groups = []
+      self = false
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+  ]
 }
 
 resource "aws_security_group" "ecs-exec" {
@@ -123,5 +159,17 @@ resource "aws_security_group" "ecs" {
       self = false
     }
   ]
-  egress  = []
+  egress  = [
+    {
+      description = " "
+      ipv6_cidr_blocks = []
+      prefix_list_ids = []
+      security_groups = []
+      self = false
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+  ]
 }

--- a/terraform/subnets.tf
+++ b/terraform/subnets.tf
@@ -1,0 +1,44 @@
+resource "aws_subnet" "public_a" {
+  vpc_id                  = aws_vpc.aws-rails-test.id
+  cidr_block              = "10.0.11.0/24"
+  availability_zone       = "ap-northeast-1a"
+  map_public_ip_on_launch = false
+
+  tags = {
+    Name = "aws-rails-test-subnet-public1-ap-northeast-1a"
+  }
+}
+
+resource "aws_subnet" "public_c" {
+  vpc_id                  = aws_vpc.aws-rails-test.id
+  cidr_block              = "10.0.12.0/24"
+  availability_zone       = "ap-northeast-1c"
+  map_public_ip_on_launch = false
+
+  tags = {
+    Name = "aws-rails-test-subnet-public2-ap-northeast-1c"
+  }
+}
+
+resource "aws_subnet" "private_a" {
+  vpc_id                  = aws_vpc.aws-rails-test.id
+  cidr_block              = "10.0.21.0/24"
+  availability_zone       = "ap-northeast-1a"
+  map_public_ip_on_launch = false
+
+  tags = {
+    Name = "aws-rails-test-subnet-private1-ap-northeast-1a"
+  }
+}
+
+
+resource "aws_subnet" "private_c" {
+  vpc_id                  = aws_vpc.aws-rails-test.id
+  cidr_block              = "10.0.22.0/24"
+  availability_zone       = "ap-northeast-1c"
+  map_public_ip_on_launch = false
+
+  tags = {
+    Name = "aws-rails-test-subnet-private2-ap-northeast-1c"
+  }
+}

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -1,0 +1,9 @@
+resource "aws_vpc" "aws-rails-test" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "aws-rails-test-vpc"
+  }
+}

--- a/terraform/vpc_endpoint.tf
+++ b/terraform/vpc_endpoint.tf
@@ -1,0 +1,71 @@
+resource "aws_vpc_endpoint" "ssm" {
+  vpc_id            = aws_vpc.aws-rails-test.id
+  service_name      = "com.amazonaws.ap-northeast-1.ssm"
+  vpc_endpoint_type = "Interface"
+
+  subnet_ids = [
+    aws_subnet.private_a.id,
+    aws_subnet.private_c.id
+  ]
+
+  security_group_ids = [
+    aws_security_group.ecs-exec.id
+  ]
+
+  tags = {
+    Name = "ecs-exec-endpoint-ssm"
+  }
+}
+
+resource "aws_vpc_endpoint" "ssmmessages" {
+  vpc_id            = aws_vpc.aws-rails-test.id
+  service_name      = "com.amazonaws.ap-northeast-1.ssmmessages"
+  vpc_endpoint_type = "Interface"
+
+  subnet_ids = [
+    aws_subnet.private_a.id,
+    aws_subnet.private_c.id
+  ]
+
+  security_group_ids = [
+    aws_security_group.ecs-exec.id
+  ]
+
+  tags = {
+    Name = "ecs-exec-endpoint-ssmmessages"
+  }
+}
+
+resource "aws_vpc_endpoint" "ec2messages" {
+  vpc_id            = aws_vpc.aws-rails-test.id
+  service_name      = "com.amazonaws.ap-northeast-1.ec2messages"
+  vpc_endpoint_type = "Interface"
+
+  subnet_ids = [
+    aws_subnet.private_a.id,
+    aws_subnet.private_c.id
+  ]
+
+  security_group_ids = [
+    aws_security_group.ecs-exec.id
+  ]
+
+  tags = {
+    Name = "ecs-exec-endpoint-ec2messages"
+  }
+}
+
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id            = aws_vpc.aws-rails-test.id
+  service_name      = "com.amazonaws.ap-northeast-1.s3"
+  vpc_endpoint_type = "Gateway"
+
+  route_table_ids = [
+    aws_route_table.private_a.id,
+    aws_route_table.private_c.id
+  ]
+
+  tags = {
+    Name = "aws-rails-test-vpce-s3"
+  }
+}


### PR DESCRIPTION
## Issue 番号
- fixes #28

## PR 概要
- 既存リソースを terraform 管理下に置くことで、再構築時の再現性を高める。

## PR 詳細
### やったこと
- import -> テンプレート修正の繰り返し。
  - 最低限必要そうなリソースを管理対象とする。
  - 修正は基本的には No Changes になるまでやる。ただし、元の設定がまずいことによりどうしても差分が出てしまったりするためある程度は妥協 or あるべき設定への修正を試みる。

### やらなかったこと
- ディレクトリ構成
  - あとで修正する。
- variable の設定
  - あとでやるかも。
- 細かいパラメータの設定
  - あとで修正する。
- destroy -> apply での再現性確認
  - 今の環境を使いたい意図があるため、もう少し待つ。

## 補足事項
- これ慣れないとつらいっすね
